### PR TITLE
Lock een afbeelding die al wordt gegenereerd. [WIP]

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -92,6 +92,19 @@ Config.define(
     'Indicates whether thumbor should enable blacklist functionality to prevent processing certain images.', 'Imaging')
 
 Config.define(
+    'USE_AUTO_BLACKLIST', False,
+    'Indicates wheter a remote 403 should result in an entry on the blacklist for that URL',
+'Imaging')
+
+Config.define(
+    'USE_FILE_LOCK', False, 
+    'Indicates to use a simple lockfile to prevent double work', 'Imaging')
+
+Config.define(
+    'FILE_LOCK_AGE_SECONDS', 10,
+    'Max time to wait for a lock to expire', 'Imaging')
+
+Config.define(
     'ENGINE_THREADPOOL_SIZE', 0,
     'Size of the thread pool used for image transformations.  The default value is 0 (don\'t use a threadpoool. '
     'Increase this if you are seeing your IOLoop getting blocked (often indicated by your upstream HTTP '

--- a/thumbor/handlers/blacklist.py
+++ b/thumbor/handlers/blacklist.py
@@ -30,7 +30,6 @@ class BlacklistHandler(ContextHandler):
         blacklist = yield self.get_blacklist_contents()
         blacklist += self.request.query + "\n"
         logger.debug('Adding to blacklist: %s' % self.request.query)
-        print('Adding to hh blacklist: %s' % self.request.query)
         self.context.modules.storage.put('blacklist.txt', blacklist)
         self.set_status(200)
 

--- a/thumbor/handlers/blacklist.py
+++ b/thumbor/handlers/blacklist.py
@@ -30,5 +30,14 @@ class BlacklistHandler(ContextHandler):
         blacklist = yield self.get_blacklist_contents()
         blacklist += self.request.query + "\n"
         logger.debug('Adding to blacklist: %s' % self.request.query)
+        print('Adding to hh blacklist: %s' % self.request.query)
         self.context.modules.storage.put('blacklist.txt', blacklist)
         self.set_status(200)
+
+    @classmethod
+    def blacklist_image(self, url):
+        blacklist = yield self.get_blacklist_contents()
+        blacklist += url + "\n"
+        logger.debug('-bi- Adding to blacklist: %s' % url)
+        self.context.modules.storage.put('blacklist.txt', blacklist)
+

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -84,8 +84,15 @@ class ImagingHandler(ContextHandler):
             if not valid:
                 self._error(400, 'Malformed URL: %s' % url)
                 return
+        # dan zet men hier een lock
+        if not self.context.modules.storage.lock_exists(self.context.request.image_url):
+            self.context.modules.storage.get_file_lock(self.context.request.image_url)
+        else: 
+            self._error(409, "Conflict URL: %s already processing." % url)
+            return
 
         self.execute_image_operations()
+        # die men hier weer verwijdert.
 
     @tornado.web.asynchronous
     def get(self, **kw):

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -85,11 +85,12 @@ class ImagingHandler(ContextHandler):
                 self._error(400, 'Malformed URL: %s' % url)
                 return
         # dan zet men hier een lock
-        if not self.context.modules.storage.lock_exists(self.context.request.image_url):
-            self.context.modules.storage.get_file_lock(self.context.request.image_url)
-        else: 
-            self._error(409, "Conflict URL: %s already processing." % url)
-            return
+        if self.context.config.USE_FILE_LOCK:
+            if not self.context.modules.storage.lock_exists(self.context.request.image_url):
+                self.context.modules.storage.get_file_lock(self.context.request.image_url)
+            else: 
+                self._error(409, "Conflict URL: %s already processing." % url)
+                return
 
         self.execute_image_operations()
         # die men hier weer verwijdert.

--- a/thumbor/loaders/__init__.py
+++ b/thumbor/loaders/__init__.py
@@ -14,6 +14,7 @@ class LoaderResult(object):
     ERROR_NOT_FOUND = 'not_found'
     ERROR_UPSTREAM = 'upstream'
     ERROR_TIMEOUT = 'timeout'
+    ERROR_FORBIDDEN = 'forbidden'
 
     def __init__(self, buffer=None, successful=True, error=None, metadata=dict()):
         '''

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -72,6 +72,8 @@ def return_contents(response, url, callback, context, req_start=None):
         if response.code == 599:
             # Return a Gateway Timeout status downstream if upstream times out
             result.error = LoaderResult.ERROR_TIMEOUT
+        elif response.code == 403: # and auto blacklist True
+            result.error = LoaderResult.ERROR_FORBIDDEN
         else:
             result.error = LoaderResult.ERROR_NOT_FOUND
 

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -72,7 +72,8 @@ def return_contents(response, url, callback, context, req_start=None):
         if response.code == 599:
             # Return a Gateway Timeout status downstream if upstream times out
             result.error = LoaderResult.ERROR_TIMEOUT
-        elif response.code == 403: # and auto blacklist True
+        elif response.code == 403 and context.config.USE_AUTO_BLACKLIST: 
+            # a 403 on S3 means file not found,
             result.error = LoaderResult.ERROR_FORBIDDEN
         else:
             result.error = LoaderResult.ERROR_NOT_FOUND

--- a/thumbor/storages/file_storage.py
+++ b/thumbor/storages/file_storage.py
@@ -137,3 +137,21 @@ class Storage(storages.BaseStorage):
             return False
         timediff = datetime.now() - datetime.fromtimestamp(getmtime(path))
         return timediff.seconds > self.context.config.STORAGE_EXPIRATION_SECONDS
+
+    def get_file_lock(self, path):
+        lock_abspath = self.path_on_filesystem(path)
+        lock = '%s.lock' % splitext(lock_abspath)[0]
+        file_dir_abspath = dirname(lock_abspath)
+        self.ensure_dir(file_dir_abspath)
+        with open(lock, 'w+') as _file:
+            _file.write('lock')
+            _file.close()
+
+    def lock_exists(self, path, path_on_filesystem=None):
+        if path_on_filesystem is None:
+            path_on_filesystem = self.path_on_filesystem(path)
+        if os.path.exists(path_on_filesystem):
+            timediff = datetime.now() - datetime.fromtimestamp(getmtime(path_on_filesystem))
+            return timediff.seconds < 60 # voorlopig een minuut
+        return False
+

--- a/thumbor/storages/file_storage.py
+++ b/thumbor/storages/file_storage.py
@@ -152,6 +152,6 @@ class Storage(storages.BaseStorage):
             path_on_filesystem = self.path_on_filesystem(path)
         if os.path.exists(path_on_filesystem):
             timediff = datetime.now() - datetime.fromtimestamp(getmtime(path_on_filesystem))
-            return timediff.seconds < 60 # voorlopig een minuut
+            return timediff.seconds < self.context.config.FILE_LOCK_AGE_SECONDS
         return False
 


### PR DESCRIPTION
De url-lock werkt binnen een proces, dit werkt binnen een machine met meerdere thumbor processen.

Indien een afbeelding niet op Amazon wordt gevonden, dan kan die afbeelding op de blacklist. Die afbeelding gaan we toch nooit meer maken
(zo is de theorie)