### PR TITLE
[DNM] Rebase on thumbor master, add cache busting header.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,10 +1,11 @@
 pipeline:
   build:
-    image: nrc/centos67-python-node:latest
+    image: nrc/centos8-python3
     pull: true
     commands:
       - yum install -y git-core
-      - yum install -y libjpeg-turbo-devel libpng-devel libcurl-devel gcc gcc-c++
+      - yum install -y libjpeg-turbo-devel libpng-devel libcurl-devel openssl-devel
+      - yum install -y python2 python2-devel python2-pip python2-virtualenv
       - make venv
       - make package
 


### PR DESCRIPTION
Commits die later gerevert zijn (zoals de pogingen tot oplossen van geheugenproblemen) zijn er uit gefilterd om dit klusje in de toekomst makkelijker te maken.

Tevens optie toegevoegd om cache te kunnen busten door een (zelf te configureren) header toe te voegen.

Deze PR is niet bedoelt om daadwerkelijk te mergen. De intentie is om master te resetten naar deze branch.

Onze changes staan helemaal onderaan de lijst van commits.