### PR TITLE
Fix 'JSONEngine' object has no attribute 'width'

### DIFF
--- a/thumbor/nmt_filters/meta_monkey.py
+++ b/thumbor/nmt_filters/meta_monkey.py
@@ -41,13 +41,14 @@ def get_matrix(matrix_image):
 
 def monkey_read(self, extension, quality):
     target_width, target_height = self.get_target_dimensions()
+    width, height = self.engine.size
     thumbor_json = {
         "thumbor": {
             "source": {
                 "url": self.path,
-                "width": self.width,
-                "height": self.height,
                 "frameCount": self.get_frame_count(),
+                "width": width,
+                "height": height,
             },
             "operations": self.operations,
             "target": {"width": target_width, "height": target_height},


### PR DESCRIPTION
Fixes 409 error on meta calls.

Error 409 is the result of the operation being locked, but the lock
is not cleared when thumbor crashes, and remains till it expires

```
curl -D - -H  "Host: images.nrc.nl" https://image01.nrc.nl/siYq11YPpajIY95L2SrMvlOeEqQ=/meta/980x588/smart/s3/static.nrc.nl/podcasts/files/2021/08/data70712359-fe6f25.jpg

HTTP/1.1 409 Conflict
Server: nginx
Date: Tue, 12 Oct 2021 11:08:34 GMT
Content-Type: text/html; charset=UTF-8
Content-Length: 0
Connection: keep-alive
```

See https://nieuwemediateam.slack.com/archives/G9GQE212Q/p1634031980424200