### PR TITLE
Return actual source width / height in meta monkey.

### DIFF
--- a/thumbor/nmt_filters/meta_monkey.py
+++ b/thumbor/nmt_filters/meta_monkey.py
@@ -46,8 +46,8 @@ def monkey_read(self, extension, quality):
             "source": {
                 "url": self.path,
                 "frameCount": self.get_frame_count(),
-                "width": self.source_width,
-                "height": self.source_height,
+                "width": self.engine.source_width,
+                "height": self.engine.source_height,
             },
             "operations": self.operations,
             "target": {"width": target_width, "height": target_height},

--- a/thumbor/nmt_filters/meta_monkey.py
+++ b/thumbor/nmt_filters/meta_monkey.py
@@ -41,14 +41,13 @@ def get_matrix(matrix_image):
 
 def monkey_read(self, extension, quality):
     target_width, target_height = self.get_target_dimensions()
-    width, height = self.engine.size
     thumbor_json = {
         "thumbor": {
             "source": {
                 "url": self.path,
                 "frameCount": self.get_frame_count(),
-                "width": width,
-                "height": height,
+                "width": self.source_width,
+                "height": self.source_height,
             },
             "operations": self.operations,
             "target": {"width": target_width, "height": target_height},


### PR DESCRIPTION
`self.engine.size` is the size after resizing. Engine keeps track of source size as `self.engine.source_width/height`.